### PR TITLE
Limitação: falta de indicador de afluência

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ As fontes oficiais destes dados são a [Comissão Nacional de Eleições](http:/
 
 ## Limitações
 
-Os resultados estão disponíveis a nível de círculo eleitoral. Seria desejável tê-los discriminados por freguesia ou, idealmente, mesa de voto.
+Os resultados estão disponíveis a nível de círculo eleitoral. Seria desejável tê-los discriminados por freguesia ou, idealmente, mesa de voto. Seria também interessante ter o indicador de afluência ao longo do dia.
 
 ## Licença
 


### PR DESCRIPTION
Os indicadores de afluência são disponibilizados ao público, tipicamente só durante o próprio acto eleitoral, e tipicamente também com uma cadência irregular. No entanto, todas as mesas de voto recolhem essa informação. Como um exemplo, para as Legislativas de 2015 são disponibilizados "números grossos", em http://www.legislativas2015.mai.gov.pt/afluencia.html , em que se apresenta apenas o número de afluência agregado de todas as mesas, e apenas com dois pontos temporais (12:00 e 16:00).
